### PR TITLE
Refactor to support multiple users

### DIFF
--- a/common.py
+++ b/common.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env /python
+"""This module provides a function for shipping logs to Airtable."""
+
+import os
+
+from airtable import Airtable
+
+airtab = Airtable(os.environ['jail_scrapers_db'], 'intakes', os.environ['AIRTABLE_API_KEY'])
+airtab_log = Airtable(os.environ['log_db'], 'log', os.environ['AIRTABLE_API_KEY'])
+
+def wrap_from_module(module):
+    def wrap_it_up(t0, new=None, total=None, function=None):
+        this_dict = {
+                'module': module,
+                'function': function,
+                'duration': round(time.time() - t0, 2),
+                'total': total,
+                'new': new
+        }
+        airtab_log.insert(this_dict, typecast=True)
+
+    return wrap_it_up

--- a/common.py
+++ b/common.py
@@ -4,7 +4,7 @@
 import os
 
 from airtable import Airtable
-import cloundinary
+import cloudinary
 from documentcloud import DocumentCloud
 
 airtab = Airtable(base_key=os.environ['jail_scrapers_db'],
@@ -15,7 +15,7 @@ airtab_log = Airtable(base_key=os.environ['log_db'],
         api_key=os.environ['AIRTABLE_API_KEY'])
 airtab_daily = Airtable(base_key=os.environ['jail_scrapers_db'],
         table_name='daily stats',
-        api_keyos.environ['AIRTABLE_API_KEY'])
+        api_key=os.environ['AIRTABLE_API_KEY'])
 
 dc = DocumentCloud(username=os.environ['DOCUMENT_CLOUD_USERNAME'],
         password=os.environ['DOCUMENT_CLOUD_PW'])

--- a/common.py
+++ b/common.py
@@ -4,9 +4,24 @@
 import os
 
 from airtable import Airtable
+import cloundinary
+from documentcloud import DocumentCloud
 
-airtab = Airtable(os.environ['jail_scrapers_db'], 'intakes', os.environ['AIRTABLE_API_KEY'])
-airtab_log = Airtable(os.environ['log_db'], 'log', os.environ['AIRTABLE_API_KEY'])
+airtab = Airtable(base_key=os.environ['jail_scrapers_db'],
+        table_name='intakes',
+        api_key=os.environ['AIRTABLE_API_KEY'])
+airtab_log = Airtable(base_key=os.environ['log_db'],
+        table_name='log',
+        api_key=os.environ['AIRTABLE_API_KEY'])
+
+dc = DocumentCloud(username=os.environ['DOCUMENT_CLOUD_USERNAME'],
+        password=os.environ['DOCUMENT_CLOUD_PW'])
+
+cloudinary.config(cloud_name='bfeldman89',
+        api_key=os.environ['CLOUDINARY_API_KEY'],
+        api_secret=os.environ['CLOUDINARY_API_SECRET'])
+
+muh_headers = {'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36'}
 
 def wrap_from_module(module):
     def wrap_it_up(t0, new=None, total=None, function=None):

--- a/common.py
+++ b/common.py
@@ -13,6 +13,9 @@ airtab = Airtable(base_key=os.environ['jail_scrapers_db'],
 airtab_log = Airtable(base_key=os.environ['log_db'],
         table_name='log',
         api_key=os.environ['AIRTABLE_API_KEY'])
+airtab_daily = Airtable(base_key=os.environ['jail_scrapers_db'],
+        table_name='daily stats',
+        api_keyos.environ['AIRTABLE_API_KEY'])
 
 dc = DocumentCloud(username=os.environ['DOCUMENT_CLOUD_USERNAME'],
         password=os.environ['DOCUMENT_CLOUD_PW'])

--- a/pdf_stuff.py
+++ b/pdf_stuff.py
@@ -7,15 +7,8 @@ import time
 from bs4 import BeautifulSoup
 import pdfkit
 import requests
-from airtable import Airtable
-from documentcloud import DocumentCloud
 import send2trash
-from common import wrap_from_module
-
-airtab = Airtable(os.environ['jail_scrapers_db'], 'intakes', os.environ['AIRTABLE_API_KEY'])
-airtab_log = Airtable(os.environ['log_db'], 'log', os.environ['AIRTABLE_API_KEY'])
-
-dc = DocumentCloud(os.environ['DOCUMENT_CLOUD_USERNAME'], os.environ['DOCUMENT_CLOUD_PW'])
+from common import airtab, airtab_log, dc, muh_headers, wrap_from_module
 
 jails_lst = [['mcdc', 'intake_number'],
              ['prcdf', 'intake_number'],
@@ -26,8 +19,6 @@ jails_lst = [['mcdc', 'intake_number'],
              ['ccdc', 'bk'],
              ['acdc', 'bk'],
              ['hcdc', 'bk']]
-
-muh_headers = {'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36'}
 
 
 def damn_it(error_message):

--- a/pdf_stuff.py
+++ b/pdf_stuff.py
@@ -10,6 +10,7 @@ import requests
 from airtable import Airtable
 from documentcloud import DocumentCloud
 import send2trash
+from common import wrap_from_module
 
 airtab = Airtable(os.environ['jail_scrapers_db'], 'intakes', os.environ['AIRTABLE_API_KEY'])
 airtab_log = Airtable(os.environ['log_db'], 'log', os.environ['AIRTABLE_API_KEY'])
@@ -33,15 +34,7 @@ def damn_it(error_message):
     print('Another fucking "Connection Error."\n', error_message)
     time.sleep(10)
 
-
-def wrap_it_up(t0, new, total=None, function=None):
-    this_dict = {'module': 'jail_scrapers/pdf_stuff.py'}
-    this_dict['function'] = function
-    this_dict['duration'] = round(time.time() - t0, 2)
-    this_dict['total'] = total
-    this_dict['new'] = new
-    airtab_log.insert(this_dict, typecast=True)
-
+wrap_it_up = wrap_from_module('jail_scrapers/pdf_stuff.py')
 
 def web_to_pdf():
     t0, i = time.time(), 0

--- a/polish_data.py
+++ b/polish_data.py
@@ -8,23 +8,15 @@ from cloudinary import uploader
 from airtable import Airtable
 from bs4 import BeautifulSoup
 from documentcloud import DocumentCloud
+from common import wrap_from_module
 
+wrap_it_up = wrap_from_module('jail_scrapers/polish_data.py')
 
 airtab = Airtable(os.environ['jail_scrapers_db'], 'intakes', os.environ['AIRTABLE_API_KEY'])
 airtab_log = Airtable(os.environ['log_db'], 'log', os.environ['AIRTABLE_API_KEY'])
 dc = DocumentCloud(os.environ['DOCUMENT_CLOUD_USERNAME'], os.environ['DOCUMENT_CLOUD_PW'])
 
 cloudinary.config(cloud_name='bfeldman89', api_key=os.environ['CLOUDINARY_API_KEY'], api_secret=os.environ['CLOUDINARY_API_SECRET'])
-
-
-def wrap_it_up(t0, new=None, total=None, function=None):
-    this_dict = {'module': 'jail_scrapers/polish_data.py'}
-    this_dict['function'] = function
-    this_dict['duration'] = round(time.time() - t0, 2)
-    this_dict['total'] = total
-    this_dict['new'] = new
-    airtab_log.insert(this_dict, typecast=True)
-
 
 def polish_data():
     """This function does runs each of the module's functions."""

--- a/polish_data.py
+++ b/polish_data.py
@@ -3,20 +3,11 @@
 import os
 import re
 import time
-import cloudinary
-from cloudinary import uploader
 from airtable import Airtable
 from bs4 import BeautifulSoup
-from documentcloud import DocumentCloud
-from common import wrap_from_module
+from common import airtab, airtab_log, cloudinary, dc, wrap_from_module
 
 wrap_it_up = wrap_from_module('jail_scrapers/polish_data.py')
-
-airtab = Airtable(os.environ['jail_scrapers_db'], 'intakes', os.environ['AIRTABLE_API_KEY'])
-airtab_log = Airtable(os.environ['log_db'], 'log', os.environ['AIRTABLE_API_KEY'])
-dc = DocumentCloud(os.environ['DOCUMENT_CLOUD_USERNAME'], os.environ['DOCUMENT_CLOUD_PW'])
-
-cloudinary.config(cloud_name='bfeldman89', api_key=os.environ['CLOUDINARY_API_KEY'], api_secret=os.environ['CLOUDINARY_API_SECRET'])
 
 def polish_data():
     """This function does runs each of the module's functions."""
@@ -37,7 +28,7 @@ def get_pixelated_mug():
         url = record["fields"]["PHOTO"][0]["url"]
         fn = record["fields"]["UID"]
         try:
-            uploader.upload(url, public_id=fn)
+            cloudinary.uploader.upload(url, public_id=fn)
         except cloudinary.api.Error as err:
             print("cloudinary can't accept that shit: ", err)
         time.sleep(1.5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+airtable-python-wrapper==0.12.0
+beautifulsoup4==4.8.1
+certifi==2019.11.28
+chardet==3.0.4
+cloudinary==1.19.1
+idna==2.8
+mock==3.0.5
+nameparser==1.0.4
+Pillow==6.2.1
+python-dateutil==2.8.1
+python-documentcloud==1.1.1
+requests==2.22.0
+rfc3987==1.3.8
+Send2Trash==1.5.0
+six==1.13.0
+soupsieve==1.9.5
+urllib3==1.25.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ cloudinary==1.19.1
 idna==2.8
 mock==3.0.5
 nameparser==1.0.4
+pdfkit==0.6.1
 Pillow==6.2.1
 python-dateutil==2.8.1
 python-documentcloud==1.1.1

--- a/scrapers.py
+++ b/scrapers.py
@@ -7,17 +7,10 @@ import urllib.parse
 import requests
 from bs4 import BeautifulSoup
 from nameparser import HumanName
-from airtable import Airtable
 import standardize
-from common import wrap_from_module
+from common import airtab, airtab_log, muh_headers, wrap_from_module
 
 wrap_it_up = wrap_from_module('jail_scrapers/scrapers.py')
-
-airtab = Airtable(os.environ['jail_scrapers_db'], 'intakes', os.environ['AIRTABLE_API_KEY'])
-airtab_log = Airtable(os.environ['log_db'], 'log', os.environ['AIRTABLE_API_KEY'])
-
-muh_headers = {'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36'}
-
 
 def get_name(raw_name, this_dict):
     name = HumanName(raw_name)

--- a/scrapers.py
+++ b/scrapers.py
@@ -9,7 +9,9 @@ from bs4 import BeautifulSoup
 from nameparser import HumanName
 from airtable import Airtable
 import standardize
+from common import wrap_from_module
 
+wrap_it_up = wrap_from_module('jail_scrapers/scrapers.py')
 
 airtab = Airtable(os.environ['jail_scrapers_db'], 'intakes', os.environ['AIRTABLE_API_KEY'])
 airtab_log = Airtable(os.environ['log_db'], 'log', os.environ['AIRTABLE_API_KEY'])
@@ -33,15 +35,6 @@ def update_record(this_dict, soup, m, lea_parser=None, raw_lea=''):
         if lea_parser:
             lea_parser(raw_lea)
     airtab.update(m['id'], this_dict, typecast=True)
-
-
-def wrap_it_up(jail, t0, new_intakes, total_intakes):
-    this_dict = {'module': 'jail_scrapers/scrapers.py'}
-    this_dict['function'] = f"{jail}_scraper"
-    this_dict['duration'] = round(time.time() - t0, 2)
-    this_dict['total'] = total_intakes
-    this_dict['new'] = new_intakes
-    airtab_log.insert(this_dict, typecast=True)
 
 
 def damn_it(error_message):

--- a/snapshot.py
+++ b/snapshot.py
@@ -2,10 +2,7 @@
 """This module does blah blah."""
 import os
 from datetime import timedelta, date
-from airtable import Airtable
-
-airtab_intakes = Airtable(os.environ['jail_scrapers_db'], 'intakes', os.environ['AIRTABLE_API_KEY'])
-airtab_daily = Airtable(os.environ['jail_scrapers_db'], 'daily stats', os.environ['AIRTABLE_API_KEY'])
+from common import airtab as airtab_intakes, airtab_daily
 
 county_jails = [('Madison', 'mcdc'),
                 ('Pearl River', 'prcdf'),


### PR DESCRIPTION
Currently, it's a little tough for multiple people to use the repo. Even if only one of us pushes to the main airtables, it makes it tough to run tests while developing new scrapers. There are a few other things that might help with ergonomics in this sense, but here are some easy wins:

* Add a requirements.txt to so it's clear what to install. (You're likely running older versions since I just installed latest, but hopefully these version changes won't break anything.)
* Move configs into a common file. Since different users will need to overwrite this config file, this makes it so that I can edit the credentials in common.py without committing, but still commit changes to scrapers.py. Long term, it might be helpful to just read credentials from a config file that's git ignored.
* Ensure the output directories for PDFs exist at runtime. This way a new user (developer) won't be surprised, and we can add new jails without worrying about what directories exist outside of source control.

Any thoughts? Happy to make adjustments as needed.